### PR TITLE
Fixed `full` predicate to return `true` at full board

### DIFF
--- a/src/tictactoe/main.cpp
+++ b/src/tictactoe/main.cpp
@@ -25,7 +25,7 @@ void reset() {
 bool full() {
     for (unsigned char i = 0; i < boardDim; ++i) {
         for (unsigned char j = 0; j < boardDim; ++j) {
-            if (board[i][j] != empty) {
+            if (board[i][j] == empty) {
                 return false;
             }
         }


### PR DESCRIPTION
As above. `/usr/tictactoe` when compiled from `main` cannot settle outcome to draw when board is full without any winners.