### PR TITLE
Support use of serial terminal

### DIFF
--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -8,7 +8,7 @@ HFILE __console_handle;
 
 void infos_main(const char *cmdline)
 {
-    __console_handle = open("/dev/console", 0);
+    __console_handle = open("/dev/tty0", 0);
     if (is_error(__console_handle))
         exit(1);
 

--- a/src/date/main.cpp
+++ b/src/date/main.cpp
@@ -12,7 +12,7 @@ static int dump_system_time(bool ol)
 		return rc;
 	}
 
-	printf("the current system date & time is: \33\x0b%02u/%02u/%u \33\x0a%02u:%02u:%02u\33\x07%c", t.day_of_month, t.month, t.year, t.hours, t.minutes, t.seconds, ol ? '\r' : '\n');
+	printf("the current system date & time is: \33[96m%02u/%02u/%u \33[39m%02u:%02u:%02u\33[39m%c", t.day_of_month, t.month, t.year, t.hours, t.minutes, t.seconds, ol ? '\r' : '\n');
 	return 0;
 }
 

--- a/src/init/main.cpp
+++ b/src/init/main.cpp
@@ -4,7 +4,7 @@
 
 int main(const char *cmdline)
 {
-	printf("\33\x0cWelcome to InfOS!\n\33\x09Starting the system...\n");
+	printf("\33[91mWelcome to InfOS!\n\33[39mStarting the system...\n");
 
 	while (true) {
 		HPROC shell_proc = exec("/usr/shell", NULL);


### PR DESCRIPTION
These patches make userspace programs generate ANSI escape codes instead of the CGA attr byte, and always open `/dev/tty0` (whatever is configured as the first terminal -- may be serial or VGA) instead of `/dev/console` (always the VGA console).

As with the corresponding changes I've pull-requested in `infos`, all this is only tested on qemu, not real hardware, but it was used successfully by a class of nearly 400 students last spring.